### PR TITLE
Update kOStok Mk 1.craft

### DIFF
--- a/e003/kOStok Mk 1.craft
+++ b/e003/kOStok Mk 1.craft
@@ -337,7 +337,7 @@ PART
 	RESOURCE
 	{
 		name = MonoPropellant
-		amount = 10
+		amount = 0
 		maxAmount = 10
 		flowState = True
 		isTweakable = True


### PR DESCRIPTION
The landing module doesn't need monopropellant.