### PR TITLE
Patch 1 - Enable Antennae Simplification

### DIFF
--- a/episodes/e037/herald_mission.ks
+++ b/episodes/e037/herald_mission.ks
@@ -90,25 +90,13 @@
   }
   
   function enable_antennae {
-		for rt in ship:modulesnamed("ModuleRTAntenna") { 
-			if rt:hasevent("no target") rt:setfield("target", "Kerbin").
-			if rt:hasevent("activate") rt:doevent("activate").
+  	parameter mission.
+	for rt in ship:modulesnamed("ModuleRTAntenna") { 
+		if rt:hasevent("no target") rt:setfield("target", "Kerbin").
+		if rt:hasevent("activate") rt:doevent("activate").
 		}
-		mission["next"]().
+	mission["next"]().
 	}
-
-//  function enable_antennae {
-//    parameter mission.
-//    local p is ship:partstitled("Comms DTS-M1")[0].
-//    local m is p:getmodule("ModuleRTAntenna").
-//    m:doevent("Activate").
-//    m:setfield("target", "Kerbin").
-
-//    set p to ship:partstitled("Communotron 16")[0].
-//    set m to p:getmodule("ModuleRTAntenna").
-//    m:doevent("Activate").
-//    mission["next"]().
-//  }
 
   function idle {
     parameter mission.

--- a/episodes/e037/herald_mission.ks
+++ b/episodes/e037/herald_mission.ks
@@ -88,19 +88,27 @@
       mission["next"]().
     }
   }
-
+  
   function enable_antennae {
-    parameter mission.
-    local p is ship:partstitled("Comms DTS-M1")[0].
-    local m is p:getmodule("ModuleRTAntenna").
-    m:doevent("Activate").
-    m:setfield("target", "Kerbin").
+		for rt in ship:modulesnamed("ModuleRTAntenna") { 
+			if rt:hasevent("no target") rt:setfield("target", "Kerbin").
+			if rt:hasevent("activate") rt:doevent("activate").
+		}
+		mission["next"]().
+	}
 
-    set p to ship:partstitled("Communotron 16")[0].
-    set m to p:getmodule("ModuleRTAntenna").
-    m:doevent("Activate").
-    mission["next"]().
-  }
+//  function enable_antennae {
+//    parameter mission.
+//    local p is ship:partstitled("Comms DTS-M1")[0].
+//    local m is p:getmodule("ModuleRTAntenna").
+//    m:doevent("Activate").
+//    m:setfield("target", "Kerbin").
+
+//    set p to ship:partstitled("Communotron 16")[0].
+//    set m to p:getmodule("ModuleRTAntenna").
+//    m:doevent("Activate").
+//    mission["next"]().
+//  }
 
   function idle {
     parameter mission.


### PR DESCRIPTION
I have been working on reusable versions of your Ep 37 libraries and mission files for my comprehensive Mission Control scripts and wanted to share some of the methods I've found for handling Modules on part categories that have broad options and configurations. Taking advantage of the Events properties of the modules and understanding that an Event goes away when its been instantiated, I came up with the method shown for Remote Tech and stock and non stock science experiments. Take a look at my version of your enable_antennae function and let me know what you think. (Obviously it can be adjusted for a more comprehensive set of target assignments for dishes, but I wanted input on the basics before I commit to something more intricate.)